### PR TITLE
Fix 404 for JS by unifying app ID

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -1,18 +1,19 @@
 <?php
 use OCP\Util;
 use OCP\IL10N;
+use OCA\HttpUploader\AppInfo\Application;
 
 // Initialize the localization service
-$l = \OC::$server->getL10N('largefileupload');
+$l = \OC::$server->getL10N(Application::APP_ID);
 
-Util::addStyle('largefileupload', 'largefileupload');
-Util::addScript('largefileupload', 'largefileupload');
+Util::addStyle(Application::APP_ID, 'largefileupload');
+Util::addScript(Application::APP_ID, 'largefileupload');
 
 $navigationEntry = [
-    'id' => 'largefileupload',
+    'id' => Application::APP_ID,
     'order' => 50,
-    'href' => \OC::$server->getURLGenerator()->linkToRoute('largefileupload.page.index'),
-    'icon' => \OC::$server->getURLGenerator()->imagePath('largefileupload', 'app.svg'),
+    'href' => \OC::$server->getURLGenerator()->linkToRoute(Application::APP_ID . '.page.index'),
+    'icon' => \OC::$server->getURLGenerator()->imagePath(Application::APP_ID, 'app.svg'),
     'name' => $l->t('Large File Upload'),
 ];
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <info>
-    <id>largefileupload</id>
+    <id>http_uploader</id>
     <name>Large File Upload</name>
     <description>An app for uploading large files to Nextcloud via chunked HTTP uploads.</description>
     <version>1.0.0</version>
     <licence>agpl</licence>
     <author>Your Name</author>
-    <namespace>LargeFileUpload</namespace>
+    <namespace>HttpUploader</namespace>
     <types>
         <filesystem/>
         <files/>

--- a/js/largefileupload.js
+++ b/js/largefileupload.js
@@ -44,7 +44,7 @@ document.addEventListener('DOMContentLoaded', () => {
             formData.append('chunk', chunk);
 
             try {
-                const response = await fetch(OC.generateUrl('/apps/largefileupload/upload/chunk'), {
+                const response = await fetch(OC.generateUrl('/apps/http_uploader/upload/chunk'), {
                     method: 'POST',
                     body: formData,
                 });
@@ -74,7 +74,7 @@ document.addEventListener('DOMContentLoaded', () => {
         formData.append('targetPath', targetPathInput.value || ''); // Default to empty if not set
 
         try {
-            const response = await fetch(OC.generateUrl('/apps/largefileupload/upload/assemble'), {
+            const response = await fetch(OC.generateUrl('/apps/http_uploader/upload/assemble'), {
                 method: 'POST',
                 body: formData,
             });

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -1,9 +1,10 @@
 <?php
-namespace OCA\LargeFileUpload\Controller;
+namespace OCA\HttpUploader\Controller;
 
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IRequest;
+use OCA\HttpUploader\AppInfo\Application;
 
 class PageController extends Controller {
     public function __construct($appName, IRequest $request) {
@@ -15,6 +16,6 @@ class PageController extends Controller {
      * @NoCSRFRequired
      */
     public function index() {
-        return new TemplateResponse('largefileupload', 'main');
+        return new TemplateResponse(Application::APP_ID, 'main');
     }
 }

--- a/lib/Controller/UploadController.php
+++ b/lib/Controller/UploadController.php
@@ -1,5 +1,5 @@
 <?php
-namespace OCA\LargeFileUpload\Controller;
+namespace OCA\HttpUploader\Controller;
 
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -32,7 +32,7 @@ class UploadController extends Controller {
             return new DataResponse(['error' => 'Invalid chunk upload'], Http::STATUS_BAD_REQUEST);
         }
 
-        $tempDir = \OC::$server->getTempManager()->getTemporaryFolder() . 'largefileupload_' . $this->userId . '_' . $fileName;
+        $tempDir = \OC::$server->getTempManager()->getTemporaryFolder() . 'http_uploader_' . $this->userId . '_' . $fileName;
         if (!is_dir($tempDir)) {
             mkdir($tempDir, 0777, true);
         }
@@ -52,7 +52,7 @@ class UploadController extends Controller {
         $totalChunks = (int)$this->request->getParam('totalChunks');
         $targetPath = $this->request->getParam('targetPath', '');
 
-        $tempDir = \OC::$server->getTempManager()->getTemporaryFolder() . 'largefileupload_' . $this->userId . '_' . $fileName;
+        $tempDir = \OC::$server->getTempManager()->getTemporaryFolder() . 'http_uploader_' . $this->userId . '_' . $fileName;
         $finalPath = $this->userFolder->getPath() . '/' . $targetPath . '/' . $fileName;
 
         try {

--- a/templates/main.php
+++ b/templates/main.php
@@ -1,6 +1,6 @@
 <?php
-style('largefileupload', 'largefileupload');
-script('largefileupload', 'largefileupload');
+style(\OCA\HttpUploader\AppInfo\Application::APP_ID, 'largefileupload');
+script(\OCA\HttpUploader\AppInfo\Application::APP_ID, 'largefileupload');
 ?>
 
 <div class="upload-container">


### PR DESCRIPTION
## Summary
- Use a consistent `http_uploader` app ID across PHP, templates, and JS
- Update asset loading and routes to match the new ID
- Adjust controller namespaces and temporary directories accordingly

## Testing
- `php -l appinfo/app.php`
- `php -l lib/Controller/PageController.php`
- `php -l lib/Controller/UploadController.php`
- `php -l templates/main.php`
- `php -l lib/AppInfo/Application.php`


------
https://chatgpt.com/codex/tasks/task_e_68add75f9b4c832faaac8dad3e72d523